### PR TITLE
Some improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# default build folder
+build/
+
+# editor specific project files
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+project(KPartiteKClique CXX)
+
+add_library(kpkc kpkc.cpp kpkc.h)
+# target_compile_features(kpkc PUBLIC cxx_std_11)


### PR DESCRIPTION
Here are some improvements to use C++11 keywords like override
Class methods are automatically inline if defined inline in the class. There is no need for that keyword.
The classes are wrapped in a namespace now. Could you test, if this is still usable in python now? I couldn't find where to adjust and test the glue-code to cpython.
I've added a very rudimentary cmake file. We could add some code to create a python module out of this translation unit.

Before merging into master I suggest to test it for any errors.

